### PR TITLE
SMP-26 Don’t fail when deploy directory doesn’t exist.

### DIFF
--- a/sakai-plugin/src/main/java/org/sakaiproject/maven/plugin/component/ComponentDeployMojo.java
+++ b/sakai-plugin/src/main/java/org/sakaiproject/maven/plugin/component/ComponentDeployMojo.java
@@ -455,8 +455,6 @@ for (Iterator iter = artifacts.iterator(); iter.hasNext();) {
 			fileName = getDeployId() + "-" + project.getVersion()
 					+ "." + project.getPackaging();
 			stubName = getDeployId() + "-" + project.getVersion();
-			// This bails out in an exception if there is a problem.
-			handleDuplicates(destination, fileName);
 		} else {
 			fileName = getDeployId() + "." + project.getPackaging();
 			stubName = getDeployId();
@@ -495,7 +493,11 @@ for (Iterator iter = artifacts.iterator(); iter.hasNext();) {
 		if (deleteStub && stubFile.exists()) {
 			deleteAll(stubFile);
 		}
-		
+		if (withVersion) {
+			// This bails out in an exception if there is a problem.
+			handleDuplicates(destination, fileName);
+		}
+
 		copyFileIfModified(artifactFile, destinationFile);
 	}
 


### PR DESCRIPTION
If the deploy directory didn’t exist then the the plugin would blow up, now we do the check after having created the directory.
