### PR TITLE
Update plexus and maven dependencies to newer version

### DIFF
--- a/sakai-plugin/pom.xml
+++ b/sakai-plugin/pom.xml
@@ -11,7 +11,7 @@
   <packaging>maven-plugin</packaging>
   <name>Sakai Component Plugin</name>
   <prerequisites>
-    <maven>3.6.1</maven>
+    <maven>3.5.4</maven>
   </prerequisites>
   <issueManagement>
     <system>JIRA</system>

--- a/sakai-plugin/pom.xml
+++ b/sakai-plugin/pom.xml
@@ -11,7 +11,7 @@
   <packaging>maven-plugin</packaging>
   <name>Sakai Component Plugin</name>
   <prerequisites>
-    <maven>3.2.5</maven>
+    <maven>3.6.1</maven>
   </prerequisites>
   <issueManagement>
     <system>JIRA</system>
@@ -31,12 +31,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
-      <version>3.1.1</version>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.24</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.4</version>
+      <version>3.6.0</version>
       <scope>provided</scope><!-- annotations are needed only to build the plugin -->
     </dependency>
     <dependency>
@@ -68,16 +68,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>default-descriptor</id>


### PR DESCRIPTION
Fixes #7 

We probably only needed to update the plexus dependency but all of these maven ones seemed outdated too.

I build with Maven 3.6.1 and it works fine locally for me. I noticed a few methods in AbstractComponentMojo were marked to be removed and removed those in #9 but this update was needed for me to build on multi-threaded for a presentation I was giving at Open Apereo.